### PR TITLE
osx fixes: working MenuBar and initial support for maximize/fullcreen win

### DIFF
--- a/c_src/Makefile.macosx
+++ b/c_src/Makefile.macosx
@@ -20,7 +20,7 @@
 #UNIVERSAL_FLAGS = $(UNIVERSAL_SDK) -arch i386 -arch ppc
 
 # or 
-UNIVERSAL_FLAGS = -arch i386
+UNIVERSAL_FLAGS = -arch i386 -arch x86_64 -arch ppc
 CC = cc
 
 #
@@ -28,9 +28,11 @@ CC = cc
 # the SDL framework has been installed in /Library/Frameworks.
 #
 
-CFLAGS	= -g -O2 -Wall -ObjC -D_THREAD_SAFE -D_REENTRANT -D_OSX_COCOA -I/Library/Frameworks/SDL.framework/Headers -F/Library/Frameworks $(ERLINC) $(UNIVERSAL_FLAGS)
+CFLAGS	= -g -O2 -Wall -ObjC -D_THREAD_SAFE -D_REENTRANT -D_OSX_COCOA $(ERLINC) $(UNIVERSAL_FLAGS) \
+	-I/Library/Frameworks/SDL.framework/Headers -I$(HOME)/Library/Frameworks/SDL.framework/Headers \
+	-F/Library/Frameworks -F$(HOME)/Library/Frameworks $(ERLINC) $(UNIVERSAL_FLAGS)
 
-LDFLAGS = -F/Library/Frameworks -framework SDL -framework IOKit -framework Carbon -framework Cocoa -L. $(UNIVERSAL_FLAGS)
+LDFLAGS = -F/Library/Frameworks -F$(HOME)/Library/Frameworks -framework SDL -framework IOKit -framework Carbon -framework Cocoa -L. $(UNIVERSAL_FLAGS)
 
 TARGETDIR = ../priv
 

--- a/c_src/esdl_driver.c
+++ b/c_src/esdl_driver.c
@@ -20,10 +20,9 @@
 #endif
 
 #ifdef _OSX_COCOA
-//#include "CPS.h"
-//#include "SDLMain.h"
-#include <Cocoa/Cocoa.h>
-#include <objc/objc-runtime.h>
+	#include <Cocoa/Cocoa.h>
+	#include <objc/objc-runtime.h>
+	#include <sys/param.h> /* for MAXPATHLEN */
 #endif
 
 #include <errno.h>
@@ -43,6 +42,63 @@ static int sdl_driver_debug_control(ErlDrvData handle, unsigned int command,
 				    char* buf, int count, char** res, int res_size);
 
 static void standard_outputv(ErlDrvData drv_data, ErlIOVec *ev);
+
+#ifdef _OSX_COCOA
+
+	static void setApplicationMenu(const char *app_name);
+	static void setupWindowMenu(void);
+	static void setupHelpMenu(const char *app_name);
+	static NSString *getApplicationName(void);
+
+	/* For some reaon, Apple removed setAppleMenu from the headers in 10.4,
+	 but the method still is there and works. To avoid warnings, we declare
+	 it ourselves here. */
+	@interface NSApplication(SDL_Missing_Methods)
+	- (void)setAppleMenu:(NSMenu *)menu;
+	@end
+
+	@interface NSApplication(SDL_Private_Methods)
+	- (void)setupWorkingDirectory:(BOOL)shouldChdir;
+	@end
+
+	@implementation NSApplication(SDL_Private_Methods)
+	/* Set the working directory to the .app's parent directory */
+	- (void) setupWorkingDirectory:(BOOL)shouldChdir
+	{
+		if (shouldChdir) {
+			char parentdir[MAXPATHLEN];
+			CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
+			CFURLRef url2 = CFURLCreateCopyDeletingLastPathComponent(0, url);
+			if (CFURLGetFileSystemRepresentation(url2, 1, (UInt8 *)parentdir, MAXPATHLEN)) {
+				chdir(parentdir);   /* chdir to the binary app's parent */
+			}
+			CFRelease(url);
+			CFRelease(url2);
+		}
+	}
+	@end
+
+	@interface SDLApplication : NSApplication
+	@end
+
+	@implementation SDLApplication : NSApplication
+	- (void)finishLaunching { [super finishLaunching]; @throw [NSException exceptionWithName:@"NSApp run escape" reason:@"SDL" userInfo:nil]; }
+	/* Invoked from the Quit menu item */
+	- (void)terminate:(id)sender
+	{
+		/* Post a SDL_QUIT event */
+		NSLog(@"SDLApplication:SDL_QUIT\n");
+		SDL_Event event;
+		event.type = SDL_QUIT;
+		SDL_PushEvent(&event);
+		[super terminate:sender];
+	}
+	- (void)performMaximize {
+	}
+	- (void)perfomFullscreen {
+	}
+	@end
+#endif
 
 /*
 ** The driver struct
@@ -75,8 +131,7 @@ static ErlDrvData sdl_driver_start(ErlDrvPort port, char *buff)
    ErlDrvSysInfo info;
 
 #ifdef _WIN32
-   if ( SDL_RegisterApp("Erlang SDL", CS_BYTEALIGNCLIENT, 
-			GetModuleHandle(NULL)) < 0 ) {
+   if ( SDL_RegisterApp("Erlang SDL", CS_BYTEALIGNCLIENT, GetModuleHandle(NULL)) < 0 ) {
       fprintf(stderr, "WinMain() error %s \n", SDL_GetError());
       return(ERL_DRV_ERROR_GENERAL);
    }
@@ -105,7 +160,7 @@ static ErlDrvData sdl_driver_start(ErlDrvPort port, char *buff)
 #else
    data->use_smp = info.smp_support && info.scheduler_threads > 1;
 #endif
-   // fprintf(stderr, "Use smp %d\r\n", data->use_smp);
+
    if(data->use_smp) {
       start_opengl_thread(data);
    } else { // The following code needs to called from main thread
@@ -124,31 +179,42 @@ void esdl_init_native_gui()
 {
 #ifdef _OSX_COCOA
    ProcessSerialNumber psn;
-   NSAutoreleasePool *pool;
 
-   // [[NSProcessInfo processInfo] setProcessName:@"Erlang"]; 
    // Enable GUI 
    GetCurrentProcess(&psn);
-   CPSSetProcessName(&psn, "Erlang");  // Undocumented function (but above doesn't work)
+   char *esdl_title = getenv("ESDL_APP_TITLE");
+   CPSSetProcessName(&psn, esdl_title?esdl_title:"Erlang");  // Undocumented function (but above doesn't work)
    TransformProcessType(&psn, kProcessTransformToForegroundApplication);
    SetFrontProcess(&psn);
 
+   // Setup and enable gui
+   NSAutoreleasePool __attribute ((unused)) *pool = [[NSAutoreleasePool alloc] init];
+   NSApplication __attribute ((unused)) *app = [SDLApplication sharedApplication]; 
+
    // Enable Cocoa calls from Carbon app
+   // (this has to be called after sharedApplication if NSApp
+   // should be SDLApplication)
    NSApplicationLoad();
 
-   // Setup and enable gui
-   pool = [[NSAutoreleasePool alloc] init];
-
-   NSApplication *app = [NSApplication sharedApplication];
-   // Load and set icon
-   
-   //NSMutableString *file = [[NSMutableString alloc] init];
-   //[file appendFormat:@"%s/%s", erl_wx_privdir, "erlang-logo64.png"];
-   //[file appendFormat:@"%s/%s", "/usr/local/lib/erlang/lib/wx-0.98.8/priv", "erlang-logo64.png"];
-   //NSImage *icon = [[NSImage alloc] initWithContentsOfFile: file];
-   //[app setApplicationIconImage: icon];
-   [app activateIgnoringOtherApps: YES];
-
+   /* Set up the menubar */
+   [NSApp setMainMenu:[[NSMenu alloc] init]];
+   setApplicationMenu(esdl_title?esdl_title:"ESDL");
+   setupWindowMenu();
+   setupHelpMenu(esdl_title?esdl_title:"ESDL");
+   [NSApp activateIgnoringOtherApps:YES];
+  
+   //
+   // This is hardest part.
+   // Read about [NSApp run] and menus here:
+   // http://www.cocoabuilder.com/archive/cocoa/186231-nsapp-run-method-and-menus.html
+   //
+   // My solution to break the [NSApp run] after initialization is to
+   // throw an exception in delegate method.
+   //
+   @try {
+  	[NSApp run]; 
+   } @catch (id exception) {
+   }
 #endif /* _OSX_COCOA */
 }
 
@@ -313,3 +379,125 @@ sdl_free_binaries(sdl_data* sd)
   }
   sd->next_bin = 0;
 }
+
+#ifdef _OSX_COCOA
+static NSString *getApplicationName(void)
+{
+	const NSDictionary *dict;
+	NSString *appName = 0;
+
+	/* Determine the application name */
+	dict = (const NSDictionary *)CFBundleGetInfoDictionary(CFBundleGetMainBundle());
+	if (dict)
+		appName = [dict objectForKey: @"CFBundleName"];
+	
+	if (![appName length])
+		appName = [[NSProcessInfo processInfo] processName];
+
+	return appName;
+}
+
+static void setApplicationMenu(const char *app_name)
+{
+    /* warning: this code is very odd */
+    NSMenu *appleMenu;
+    NSMenuItem *menuItem;
+    NSString *title;
+    NSString *appName;
+    
+    appName = [NSString stringWithCString:app_name encoding:NSUTF8StringEncoding];
+    appleMenu = [[NSMenu alloc] initWithTitle:@""];
+    
+    /* Add menu items */
+    title = [@"About " stringByAppendingString:appName];
+    [appleMenu addItemWithTitle:title action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
+
+    [appleMenu addItem:[NSMenuItem separatorItem]];
+
+    title = [@"Hide " stringByAppendingString:appName];
+    [appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@"h"];
+
+    menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
+    [menuItem setKeyEquivalentModifierMask:(NSAlternateKeyMask|NSCommandKeyMask)];
+
+    [appleMenu addItemWithTitle:@"Show All" action:@selector(unhideAllApplications:) keyEquivalent:@""];
+
+    [appleMenu addItem:[NSMenuItem separatorItem]];
+
+    title = [@"Quit " stringByAppendingString:appName];
+    [appleMenu addItemWithTitle:title action:@selector(terminate:) keyEquivalent:@"q"];
+
+    
+    /* Put menu into the menubar */
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+    [menuItem setSubmenu:appleMenu];
+    [[NSApp mainMenu] addItem:menuItem];
+
+    /* Tell the application object that this is now the application menu */
+    [NSApp setAppleMenu:appleMenu];
+
+    /* Finally give up our references to the objects */
+    [appleMenu release];
+    [menuItem release];
+}
+
+/* Create a window menu */
+static void setupWindowMenu(void)
+{
+    NSMenu      *windowMenu;
+    NSMenuItem  *windowMenuItem;
+    NSMenuItem  *menuItem;
+
+    windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
+    
+    /* "Minimize" item */
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@"M"];
+    [windowMenu addItem:menuItem];
+    [menuItem release];
+    /* "Maximize" item */
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"Maximize" action:@selector(performMaximize:) keyEquivalent:@"m"];
+    [windowMenu addItem:menuItem];
+    [menuItem release];
+    /* "Fullscreen" item */
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"Fullscreen" action:@selector(performFullscreen:) keyEquivalent:@"F"];
+    [windowMenu addItem:menuItem];
+    [menuItem release];
+    
+    /* Put menu into the menubar */
+    windowMenuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
+    [windowMenuItem setSubmenu:windowMenu];
+    [[NSApp mainMenu] addItem:windowMenuItem];
+    
+    /* Tell the application object that this is now the window menu */
+    [NSApp setWindowsMenu:windowMenu];
+
+    /* Finally give up our references to the objects */
+    [windowMenu release];
+    [windowMenuItem release];
+}
+
+/* Create a window menu */
+static void setupHelpMenu(const char *app_name)
+{
+	NSMenu      *helpMenu;
+	NSMenuItem  *helpMenuItem;
+	NSMenuItem  *menuItem;
+
+    helpMenu = [[NSMenu alloc] initWithTitle:@"Help"];
+
+    /* "Help" item */
+    NSString *appName = [NSString stringWithCString:app_name encoding:NSUTF8StringEncoding];
+    menuItem = [[NSMenuItem alloc] initWithTitle:[appName stringByAppendingString:@" Help"] action:@selector(tuxpaintHelp:) keyEquivalent:@"?"];
+    [helpMenu addItem:menuItem];
+    [menuItem release];
+
+    /* Put menu into the menubar */
+    helpMenuItem = [[NSMenuItem alloc] initWithTitle:@"Help" action:nil keyEquivalent:@""];
+    [helpMenuItem setSubmenu:helpMenu];
+    [[NSApp mainMenu] addItem:helpMenuItem];
+
+    /* Finally give up our references to the objects */
+    [helpMenu release];
+    [helpMenuItem release];
+}
+#endif

--- a/c_src/esdl_gen.c
+++ b/c_src/esdl_gen.c
@@ -13,6 +13,10 @@
 #include "esdl.h"
 #include <string.h>
 
+#ifdef _OSX_COCOA
+	#include <AppKit/NSScreen.h>
+#endif
+
 void es_init(sdl_data *sd, int len, char *bp) 
 {
    Uint32 mode;
@@ -22,6 +26,11 @@ void es_init(sdl_data *sd, int len, char *bp)
      char* e = SDL_GetError();
      fprintf(stderr, "Couldn't initialize SDL: %s\n\r", e);
    }
+#ifdef _OSX_COCOA
+   char sz[64];
+   NSRect fullframe = [[NSScreen mainScreen] frame]; snprintf(sz, 64, "%d,%d", (int)fullframe.size.width, (int)fullframe.size.height); setenv("SDL_VIDEO_WINDOW_FULLSCREEN_SIZE", sz, YES);
+   NSRect prefframe = [[NSScreen mainScreen] visibleFrame]; snprintf(sz, 64, "%d,%d", (int)fullframe.size.width, (int)prefframe.size.height); setenv("SDL_VIDEO_WINDOW_MAXIMIZE_SIZE", sz, YES);
+#endif
 }
 
 void es_quit(sdl_data *sd, int len, char * buff) 

--- a/c_src/esdl_gl.c
+++ b/c_src/esdl_gl.c
@@ -257,63 +257,63 @@ void * esdl_gl_main_loop(void *sd) {
 	     /* OpenGL must be initilized in the thread */
 	     switch(esdl_q[esdl_q_first].op) {
 	     case SDL_GL_SwapBuffersFunc:
-		 SDL_GL_SwapBuffers();
-		 break;
+		   SDL_GL_SwapBuffers();
+		   break;
 		 /* Events must be handled in this thread on windows */
 	     case SDL_PumpEventsFunc:
-		 SDL_PumpEvents();
-		 break;
+		   SDL_PumpEvents();
+		   break;
 	     case SDL_PeepEventsFunc:
-		 es_peepEvents2(port, esdl_q[esdl_q_first].caller, 
+		   es_peepEvents2(port, esdl_q[esdl_q_first].caller, 
 				esdl_q[esdl_q_first].buff);
 		 break;
 	     case SDL_PollEventFunc:
-		 es_pollEvent2(port, esdl_q[esdl_q_first].caller);
-		 break;
+		   es_pollEvent2(port, esdl_q[esdl_q_first].caller);
+		   break;
 	     case SDL_WaitEventFunc:
-		 es_waitEvent2(port, esdl_q[esdl_q_first].caller);
-		 break;	     
+		   es_waitEvent2(port, esdl_q[esdl_q_first].caller);
+		   break;	     
 		 /* Other gl related functions */
 
 	     case SDL_SetVideoModeFunc:
-		 es_setVideoMode2(port, esdl_q[esdl_q_first].caller, 
+		   es_setVideoMode2(port, esdl_q[esdl_q_first].caller, 
 				  esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_VideoModeOKFunc:
-		 es_videoModeOK2(port, esdl_q[esdl_q_first].caller, 
+		   es_videoModeOK2(port, esdl_q[esdl_q_first].caller, 
 				 esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_WM_ToggleFullScreenFunc:
-		 es_wm_toggleFullScreen2(port, esdl_q[esdl_q_first].caller, 
+		   es_wm_toggleFullScreen2(port, esdl_q[esdl_q_first].caller, 
 					 esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case ESDL_OpenglInitFunc:
-		 es_init_opengl2(port, esdl_q[esdl_q_first].caller, 
+		   es_init_opengl2(port, esdl_q[esdl_q_first].caller, 
 				 esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_GL_GetAttributeFunc:
-		 es_gl_getAttribute2(port, esdl_q[esdl_q_first].caller, 
+		   es_gl_getAttribute2(port, esdl_q[esdl_q_first].caller, 
 				     esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_GL_SetAttributeFunc:
-		 es_gl_setAttribute2(port, esdl_q[esdl_q_first].caller, 
+		   es_gl_setAttribute2(port, esdl_q[esdl_q_first].caller, 
 				     esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_ShowCursorFunc:
-		 es_showCursor2(port, esdl_q[esdl_q_first].caller, 
+		   es_showCursor2(port, esdl_q[esdl_q_first].caller, 
 				esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_WM_SetCaptionFunc:
-		 es_wm_setCaption2(esdl_q[esdl_q_first].buff);
-		 break;
+		   es_wm_setCaption2(esdl_q[esdl_q_first].buff);
+		   break;
 	     case SDL_WM_GetInfoFunc:
-		 es_wm_getInfo2(port, esdl_q[esdl_q_first].caller, 
+		   es_wm_getInfo2(port, esdl_q[esdl_q_first].caller, 
 				esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     case SDL_WM_MaximizeFunc:
-		 es_wm_maximize2(port, esdl_q[esdl_q_first].caller, 
+		   es_wm_maximize2(port, esdl_q[esdl_q_first].caller, 
 				 esdl_q[esdl_q_first].buff);
-		 break;
+		   break;
 	     }
 	 }
 	 for(i=0; i < esdl_q[esdl_q_first].no_bins; i++)

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,4 +23,4 @@ ERLINC = ../include
 ERL_COMPILE_FLAGS = -pa ../../esdl/ebin
 
 %.beam: $(ESRC)/%.erl
-	$(ERLC) -W -I$(ERLINC) -bbeam $(ERL_FLAGS) $(ERL_COMPILE_FLAGS) -o$(EBIN) $<
+	$(ERLC) -W -I$(ERLINC) -I../.. -bbeam $(ERL_FLAGS) $(ERL_COMPILE_FLAGS) -o$(EBIN) $<


### PR DESCRIPTION
osx fixes: working MenuBar and initial support for maximize/fullcreen window. This code require patched SDL for accessing native Cocoa window in SDL_SysWMinfo callc.
