### PR TITLE
Starting maximized in Windows

### DIFF
--- a/c_src/esdl_video.c
+++ b/c_src/esdl_video.c
@@ -878,6 +878,7 @@ void es_wm_maximize2(ErlDrvPort port, ErlDrvTermData caller, char *buff)
 {
 #ifdef _WIN32
     SDL_SysWMinfo info;
+	SDL_VERSION(&info.version);
     SDL_GetWMInfo(&info);
     ShowWindow(info.window, SW_SHOWMAXIMIZED);
 #endif


### PR DESCRIPTION
On my Windows XP machine, Wing3D wasn't maximizing the window on startup, even though it was configured to.  My small change fixes it.
